### PR TITLE
fix: 在仅有预发布记录的仓库中运行抛出not found的问题

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -76,11 +76,6 @@ async function run() {
 
     const octokit = github.getOctokit(myToken);
 
-    const response = await octokit.rest.repos.getLatestRelease({
-      owner,
-      repo,
-    });
-
     if (enablePrerelease) {
       const releasesResponse = await octokit.request('GET /repos/{owner}/{repo}/releases', {
         owner,
@@ -88,7 +83,7 @@ async function run() {
       });
       // 接口返回的 release 是有顺序的, 在前面的就是最新的, 取第一个即可, 如果没有pre release, 就用正式的
       const latestPreReleaseData =
-        (releasesResponse.data || []).find(item => item.prerelease) || response.data;
+        (releasesResponse.data || []).find(item => item.prerelease) || releasesResponse.data[0];
 
       sendReleaseNotice({
         responseData: latestPreReleaseData,
@@ -96,10 +91,15 @@ async function run() {
         currentRepo,
         dingTalkTokens,
         atAll,
-        enablePrerelease: true,
+        enablePrerelease,
       });
       return;
     }
+
+    const response = await octokit.rest.repos.getLatestRelease({
+      owner,
+      repo,
+    });
 
     sendReleaseNotice({
       responseData: response.data,


### PR DESCRIPTION
当 release types 为 published 时，支持发布和预发布时触发事件。假如一个新仓库仅有 prerelease 记录，且设置 `enable_prerelease` 为 true 时。
```
  release:
    types:
      - published

enable_prerelease: true
```
会抛出 Not Found 错误。
在 action 中报错如下图
![image](https://user-images.githubusercontent.com/15177000/162969943-a69b0514-7767-4475-a90e-bccd9665cf5e.png)
URL 请求返回报错如下图
![image](https://user-images.githubusercontent.com/15177000/162969977-f935b95e-2a8e-4b07-890d-384ae34ec5f8.png)

这是因为原代码默认会通过 `https://api.github.com/repos/owner/repo/releases/latest` 先读 releases/latest，而 prerelease 不属于 latest，所以在仅有 prerelease 的仓库，这个 API 拿不到数据抛出了上述错误。
![image](https://user-images.githubusercontent.com/15177000/162970314-dbdcaf2b-57af-455e-a889-049aa2cd67b4.png)

这个 PR 的改动为，如果 `enablePrerelease` 为 true，读取 releases。如果 `enablePrerelease` 为 false，才读取 releases/latest。

